### PR TITLE
Allow control over the format the value binding takes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Don't forget to import flatpickr's stylesheets as well.
 
 The selected date(s) can be obtained using hooks or binding to `value`.
 
+The format of the date expected can be controlled with the prop `dateFormat`, which will take a date format acceptable to Flatpickr.
+
 ### Hooks
 
 Hooks can be specified normally in the options object, or by listening to the svelte event.

--- a/src/Flatpickr.svelte
+++ b/src/Flatpickr.svelte
@@ -20,12 +20,13 @@
 
 	export let value = '';
 	export let element = null;
+	export let dateFormat = null;
 
 	let { options = {}, ...props } = $$props;
 
 	let input, fp;
 
-	$: if (fp) fp.setDate(value);
+	$: if (fp) fp.setDate(value, false, dateFormat);
 
 	onMount(() => {
 		const elem = element || input


### PR DESCRIPTION
This is a critical feature in that binding to stores which make use of `setValue` to manipulate the output value, then can't parse the bound value afterwards. This gives control to the user over what that format is.