### PR TITLE
Prevent replacing defaultDate with empty value

### DIFF
--- a/src/Flatpickr.svelte
+++ b/src/Flatpickr.svelte
@@ -24,7 +24,7 @@
 		fp = undefined;
 	export { fp as flatpickr };
 
-	$: if (fp && ready) {
+	$: if (fp && ready && value) {
 		fp.setDate(value, false, dateFormat);
 	}
 


### PR DESCRIPTION
When 'multiple' mode is used, the dates specified by `defaultDate` are currently being replaced in this line:
```js
$: if (fp && ready) {
  fp.setDate(value, false, dateFormat);
}
```

This fix allows setDate to be called only if the user actually specified a value. 

Tested with options:

```js
const options = {
  noCalendar: false,
  enableTime: true,
  inline: true,
  defaultDate: ["2016-10-20", "2016-11-04"],
  mode: 'multiple'
}
```