### PR TITLE
Make children prop optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-flatpickr",
-	"version": "3.3.5",
+	"version": "3.3.6",
 	"description": "Flatpickr component for Svelte",
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.js",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,7 +7,7 @@ export type HookProps = [Date[], string, flatpickr.Instance];
 
 declare module 'svelte-flatpickr' {
 	export interface SvelteFlatpickrProps {
-		children: unknown;
+		children?: unknown;
 		value?: Date | string | Date[] | null;
 		formattedValue?: string;
 		element?: HTMLInputElement | string;


### PR DESCRIPTION
The Flatpickr component has an optional fallback for its default slot [here](https://github.com/jacobmischka/svelte-flatpickr/blob/48988c8287d07ad79e5f994cacbf2ef0df360491/src/Flatpickr.svelte#L129).
The current typing, as far as Svelte 5 is concerned, expects something to always be provided to go in the slot. 
Making the `children` prop optional means that Svelte 5 will now allow the optional fallback to be used instead of always expecting something to be provided for the slot.